### PR TITLE
build fixes for when openssl engine is disabled

### DIFF
--- a/src/imaevm.h
+++ b/src/imaevm.h
@@ -27,8 +27,8 @@
 #include <openssl/rsa.h>
 #include <openssl/opensslconf.h>
 
-#if !defined(OPENSSL_NO_ENGINE) && !defined(OPENSSL_NO_DYNAMIC_ENGINE)
-# include <openssl/engine.h>
+#if CONFIG_IMA_EVM_ENGINE
+#include <openssl/engine.h>
 #else
 struct engine_st;
 typedef struct engine_st ENGINE; /* unused when no engine support */

--- a/src/libimaevm.c
+++ b/src/libimaevm.c
@@ -37,7 +37,9 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
+#if CONFIG_IMA_EVM_ENGINE
 #include <openssl/engine.h>
+#endif
 
 #if CONFIG_IMA_EVM_PROVIDER
 #include <openssl/provider.h>


### PR DESCRIPTION
Add and fix checks for building with the option for disabling the openssl engine option. In cases now
it's possible that engine.h now actually may not be present as distros may split out the engine support into other devel packages. This fixes the builds.