### PR TITLE
build: Fix build when openssl/engine.h is not available anymore

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,7 @@ AC_ARG_ENABLE(sigv1,
 AC_ARG_ENABLE(engine,
 	      [AS_HELP_STRING([--disable-engine], [build ima-evm-utils without OpenSSL engine support])],,[enable_engine=yes])
 	AC_CHECK_LIB([crypto], [ENGINE_init],, [enable_engine=no])
+	AC_CHECK_HEADERS(openssl/engine.h, , [enable_engine=no])
 	AM_CONDITIONAL([CONFIG_IMA_EVM_ENGINE], [test "x$enable_engine" = "xyes"])
 
 AC_ARG_ENABLE(provider,

--- a/src/imaevm.h
+++ b/src/imaevm.h
@@ -27,7 +27,8 @@
 #include <openssl/rsa.h>
 #include <openssl/opensslconf.h>
 
-#if !defined(OPENSSL_NO_ENGINE) && !defined(OPENSSL_NO_DYNAMIC_ENGINE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(OPENSSL_NO_DYNAMIC_ENGINE) \
+ && !defined(OPENSSL_NO_STATIC_ENGINE)
 # include <openssl/engine.h>
 #else
 struct engine_st;

--- a/src/libimaevm.c
+++ b/src/libimaevm.c
@@ -37,7 +37,10 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
+
+#if CONFIG_IMA_EVM_ENGINE
 #include <openssl/engine.h>
+#endif
 
 #if CONFIG_IMA_EVM_PROVIDER
 #include <openssl/provider.h>


### PR DESCRIPTION
On Fedora Rawhide openssl/engine.h has disappeared, indicating the disablement of the engine. Therefore check for openssl/engine.h and disable building with engine support if the file is not found.

In libimaevm.c #include openssl/engine.h only when CONFIG_IMA_EVM_ENGINE is set.

In the public header file imaevm.h only #include the file when OPENSSL_NO_STATIC_ENGINE is not set, which is now set in Fedora Rawhide.