### PR TITLE
evmctl: extend and verify TPM SM3 bank

### DIFF
--- a/src/evmctl.c
+++ b/src/evmctl.c
@@ -1782,7 +1782,7 @@ static void set_bank_info(struct tpm_bank_info *bank, const char *algo_name)
 static struct tpm_bank_info *init_tpm_banks(int *num_banks)
 {
 	struct tpm_bank_info *banks = NULL;
-	const char *default_algos[] = {"sha1", "sha256"};
+	const char *default_algos[] = {"sha1", "sha256", "sm3"};
 	int num_algos = sizeof(default_algos) / sizeof(default_algos[0]);
 	int i, j;
 
@@ -2858,7 +2858,7 @@ static void usage(void)
 
 	printf(
 		"\n"
-		"  -a, --hashalgo     sha1, sha224, sha256, sha384, sha512, streebog256, streebog512 (default: %s)\n"
+		"  -a, --hashalgo     sha1, sha224, sha256, sha384, sha512, sm3, streebog256, streebog512 (default: %s)\n"
 		"  -s, --imasig       make IMA signature\n"
 		"      --veritysig    sign an fs-verity file digest hash\n"
 		"  -d, --imahash      make IMA hash\n"

--- a/src/pcr_tss.c
+++ b/src/pcr_tss.c
@@ -79,6 +79,8 @@ static TPM2_ALG_ID algo_to_tss2(const char *algo_name)
 		return TPM2_ALG_SHA1;
 	else if (!strcmp(algo_name, "sha256"))
 		return TPM2_ALG_SHA256;
+	else if (!strcmp(algo_name, "sm3"))
+		return TPM2_ALG_SM3_256;
 
 	return TPM2_ALG_ERROR;
 }


### PR DESCRIPTION
When setting CONFIG_IMA_DEFAULT_HASH="sm3" in the kernel, we should
support to replay IMA measurement with the command of evmctl ima_measurement.
This patch support SM3 hash algorithm for this scene with the command of
`evmctl ima_measurement /sys/kernel/security/ima/binary_runtime_measurements -v
--key $keypath`, then using the value of `tpm2_pcrread sm3_256` PCR10 to compare
whether the ima measurement are the same.

Signed-off-by: Loong Qin <zhuolong.lq@alibaba-inc.com>
Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>
