### PR TITLE
Continue improving the test infrastructure and ci environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
               TST_ENV: um
               TST_KERNEL: ../../linux
               TST_EVM_CHANGE_MODE: 1
+              TESTGROUP: kernel
 
           - container: "quay.io/centos/centos:stream9"
             env:
@@ -260,4 +261,4 @@ jobs:
       run: $CC --version
 
     - name: Compile
-      run: CC="$CC" VARIANT="$VARIANT" COMPILE_SSL="$COMPILE_SSL" TST_ENV="$TST_ENV" TST_KERNEL="$TST_KERNEL" ./build.sh
+      run: CC="$CC" VARIANT="$VARIANT" COMPILE_SSL="$COMPILE_SSL" TST_ENV="$TST_ENV" TST_KERNEL="$TST_KERNEL" TESTGROUP="$TESTGROUP" ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -77,10 +77,16 @@ $CC --version
 echo "CFLAGS: '$CFLAGS'"
 echo "LDFLAGS: '$LDFLAGS'"
 echo "PREFIX: '$PREFIX'"
+echo "TESTGROUP: '$TESTGROUP'"
+
+disable_kernel_tests=""
+if [ "$TESTGROUP" != "kernel" ]; then
+	disable_kernel_tests="--disable-kerneltests"
+fi
 
 title "configure"
 ./autogen.sh
-./configure --prefix=$PREFIX $host || log_exit config.log "configure failed"
+./configure --prefix=$PREFIX $disable_kernel_tests $host || log_exit config.log "configure failed"
 
 title "make"
 make -j$(nproc)

--- a/ci/alpine.sh
+++ b/ci/alpine.sh
@@ -41,6 +41,7 @@ apk add \
 	openssl-dev \
 	pkgconfig \
 	procps \
+	sed \
 	sudo \
 	util-linux \
 	wget \

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,10 @@ AC_ARG_ENABLE(provider,
 	AC_CHECK_LIB([crypto], [OSSL_PROVIDER_load],, [enable_provider=no])
 	AM_CONDITIONAL([CONFIG_IMA_EVM_PROVIDER], [test "x$enable_provider" = "xyes"])
 
+AC_ARG_ENABLE(kerneltests,
+	      [AS_HELP_STRING([--enable-kerneltests], [Run the kernel tests (default: yes)])], [enable_kerneltests=$enableval], [enable_kerneltests=yes])
+	AM_CONDITIONAL([KERNEL_TESTS], [test "x$enable_kerneltests" = "xyes"])
+
 #debug support - yes for a while
 PKG_ARG_ENABLE(debug, "yes", DEBUG, [Enable Debug support])
 if test $pkg_cv_enable_debug = yes; then
@@ -107,6 +111,7 @@ echo    "         ibmtss: $ac_cv_header_ibmtss_tss_h"
 echo    "         sigv1:  $enable_sigv1"
 echo    "         engine: $enable_engine"
 echo    "       provider: $enable_provider"
+echo    "   kernel-tests: $enable_kerneltests"
 echo	"            doc: $have_doc"
 echo	"         pandoc: $have_pandoc"
 echo

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,11 @@
 check_SCRIPTS =
 TESTS = $(check_SCRIPTS)
 
-SUBDIRS = . kernel
+SUBDIRS = .
+
+if KERNEL_TESTS
+SUBDIRS += kernel
+endif
 
 check_SCRIPTS += ima_hash.test sign_verify.test boot_aggregate.test \
 		 ima_policy_check.test

--- a/tests/kernel/Makefile.am
+++ b/tests/kernel/Makefile.am
@@ -1,5 +1,7 @@
 check_SCRIPTS =
+if KERNEL_TESTS
 TESTS = $(check_SCRIPTS)
+endif
 
 check_SCRIPTS += fsverity.test portable_signatures.test mmap_check.test \
 		 evm_hmac.test non_action_rule_flags.test


### PR DESCRIPTION
The kernel tests require additional infrastructure setup to run.  Instead of skipping the tests, simply limit running them in specific environments (e.g. uml). 

Continue with other cleanup (e.g. busybox version of 'sed' doesn't work).