### PR TITLE
Add support for V3 signatures for EVM & IMA for all supported key types

### DIFF
--- a/README
+++ b/README
@@ -84,6 +84,8 @@ OPTIONS
       --provider p   preload OpenSSL provider (such as: pkcs11)
       --ignore-violations ignore ToMToU measurement violations
       --hmackey      path to symmetric key (default: /etc/keys/evm-key-plain)
+      --v2           create V2 signatures; this is the default
+      --v3           create V3 signatures; this requires Linux 7.1 or later
   -v                 increase verbosity level
   -h, --help         display this help and exit
 
@@ -139,7 +141,7 @@ evmctl '--smack' options enables that.
 Key and signature formats
 -------------------------
 
-Linux integrity subsystem supports two type of signature and respectively two
+Linux integrity subsystem supports three types of signature and respectively two
 key formats.
 
 First key format (v1) is pure RSA key encoded in PEM a format and uses own signature
@@ -149,7 +151,7 @@ for signing and importing the key.
 Second key format uses X509 DER encoded public key certificates and uses asymmetric key support
 in the kernel (since kernel 3.9). CONFIG_INTEGRITY_ASYMMETRIC_KEYS must be enabled (default).
 
-For v2 signatures x509 certificate (containing the public key) could be appended to the
+For v2 and v3 signatures x509 certificate (containing the public key) could be appended to the
 private key (they both are in PEM format) to automatically extract keyid from its Subject
 Key Identifier (SKID).
 

--- a/src/evmctl.c
+++ b/src/evmctl.c
@@ -564,8 +564,10 @@ out:
 
 static int sign_evm(const char *file, char *hash_algo, const char *key)
 {
-	unsigned char hash[MAX_DIGEST_SIZE];
 	unsigned char sig[MAX_SIGNATURE_SIZE];
+	unsigned char hash[MAX_DIGEST_SIZE];
+	enum evm_ima_xattr_type xattr_type;
+	unsigned char *psig;
 	size_t len;
 	int err;
 
@@ -575,22 +577,37 @@ static int sign_evm(const char *file, char *hash_algo, const char *key)
 	len = (size_t)err;
 	assert(len <= sizeof(hash));
 
-	err = imaevm_signhash(hash_algo, hash, len, key, g_keypass,
-			      sig + 1, sigflags, &access_info, imaevm_keyid);
-	if (err <= 1)
-		return err;
-	len = (size_t)err;
-	assert(len <= sizeof(sig));
-
-	/* add header */
-	len++;
 	if (evm_portable)
-		sig[0] = EVM_XATTR_PORTABLE_DIGSIG;
+		xattr_type = EVM_XATTR_PORTABLE_DIGSIG;
 	else
-		sig[0] = EVM_IMA_XATTR_DIGSIG;
+		xattr_type = EVM_IMA_XATTR_DIGSIG;
 
-	if (evm_immutable)
-		sig[1] = 3; /* immutable signature version */
+	switch (g_signature_version) {
+	case SIGNATURE_V3:
+		psig = sig;
+		err = imaevm_create_sigv3(hash_algo, hash, len, key, g_keypass,
+					  &psig, sizeof(sig), sigflags,
+					  xattr_type, &access_info,
+					  imaevm_keyid);
+		if (err <= 1)
+			return err;
+		len = (size_t)err;
+		assert(len <= sizeof(sig));
+		break;
+	case SIGNATURE_V2:
+		err = imaevm_signhash(hash_algo, hash, len, key, g_keypass,
+				      sig + 1, sigflags, &access_info, imaevm_keyid);
+		if (err <= 1)
+			return err;
+		len = (size_t)err;
+		assert(len <= sizeof(sig));
+		/* add header */
+		len++;
+		sig[0] = xattr_type;
+		if (evm_immutable)
+			sig[1] = 3; /* immutable signature version */
+		break;
+	}
 
 	if (sigdump || imaevm_params.verbose >= LOG_INFO)
 		imaevm_hexdump(sig, len);

--- a/src/evmctl.c
+++ b/src/evmctl.c
@@ -995,7 +995,7 @@ static int verify_evm(struct public_key_entry *public_keys, const char *file)
 	}
 
 	if (sig[0] == EVM_XATTR_PORTABLE_DIGSIG) {
-		if (sig[1] != DIGSIG_VERSION_2) {
+		if (sig[1] != DIGSIG_VERSION_2 && sig[1] != DIGSIG_VERSION_3) {
 			log_err("Portable sig: invalid type\n");
 			return -1;
 		}

--- a/src/evmctl.c
+++ b/src/evmctl.c
@@ -123,6 +123,13 @@ static bool hwtpm;
 static char *g_hash_algo = DEFAULT_HASH_ALGO;
 static char *g_keypass;
 
+enum signature_version {
+	SIGNATURE_V2 = 2,
+	SIGNATURE_V3,
+};
+
+static enum signature_version g_signature_version = SIGNATURE_V2;
+
 #define HMAC_FLAG_NO_UUID	0x0001
 #define HMAC_FLAG_CAPS_SET	0x0002
 
@@ -652,6 +659,7 @@ static int sign_ima(const char *file, char *hash_algo, const char *key)
 {
 	unsigned char hash[MAX_DIGEST_SIZE];
 	unsigned char sig[MAX_SIGNATURE_SIZE];
+	unsigned char *psig;
 	size_t len;
 	int err;
 
@@ -661,16 +669,35 @@ static int sign_ima(const char *file, char *hash_algo, const char *key)
 	len = (size_t)err;
 	assert(len <= sizeof(hash));
 
-	err = imaevm_signhash(hash_algo, hash, len, key, g_keypass,
-			      sig + 1, sigflags, &access_info, imaevm_keyid);
-	if (err <= 1)
-		return err;
-	len = (size_t)err;
-	assert(len < sizeof(sig));
-
-	/* add header */
-	len++;
-	sig[0] = EVM_IMA_XATTR_DIGSIG;
+	switch (g_signature_version) {
+	case SIGNATURE_V3:
+		psig = sig;
+		err = imaevm_create_sigv3(hash_algo, hash, len, key, g_keypass,
+					  &psig, sizeof(sig), sigflags,
+					  EVM_IMA_XATTR_DIGSIG, &access_info,
+					  imaevm_keyid);
+		if (err <= 1)
+			return err;
+		len = (size_t)err;
+		assert(len <= sizeof(sig));
+		break;
+	case SIGNATURE_V2:
+		err = imaevm_signhash(hash_algo, hash, len, key, g_keypass,
+				      sig + 1, sigflags, &access_info,
+				      imaevm_keyid);
+		if (err <= 1)
+			return err;
+		len = (size_t)err;
+		assert(len < sizeof(sig));
+		/* add header */
+		len++;
+		sig[0] = EVM_IMA_XATTR_DIGSIG;
+		break;
+	default:
+		log_err("Internal error: Unsupported signature version: %d\n",
+			g_signature_version);
+		return -1;
+	}
 
 	if (sigdump || imaevm_params.verbose >= LOG_INFO)
 		imaevm_hexdump(sig, len);
@@ -791,6 +818,7 @@ static int cmd_sign_hash(struct command *cmd)
 	size_t hashlen = 0;
 	int siglen;
 	char *line = NULL, *token, *hashp;
+	unsigned char *psig;
 	size_t line_len = 0;
 	const char *key;
 	char algo[7];	/* Current maximum fsverity hash algo name length */
@@ -863,20 +891,39 @@ static int cmd_sign_hash(struct command *cmd)
 			assert(hashlen / 2 <= sizeof(hash));
 			hex2bin(hash, line, hashlen / 2);
 
-			siglen = imaevm_signhash(g_hash_algo, hash,
-						 hashlen / 2, key, g_keypass,
-						 sig + 1, sigflags,
-						 &access_info, imaevm_keyid);
-			sig[0] = EVM_IMA_XATTR_DIGSIG;
+			switch (g_signature_version) {
+			case SIGNATURE_V3:
+				psig = sig;
+				siglen = imaevm_create_sigv3(g_hash_algo, hash,
+							     hashlen / 2, key, g_keypass,
+							     &psig, sizeof(sig), sigflags,
+							     EVM_IMA_XATTR_DIGSIG,
+							     &access_info, imaevm_keyid);
+				if (siglen <= 1)
+					return siglen;
+				assert(siglen <= (int)sizeof(sig));
+				break;
+			case SIGNATURE_V2:
+				siglen = imaevm_signhash(g_hash_algo, hash,
+							 hashlen / 2, key, g_keypass,
+							 sig + 1, sigflags,
+							 &access_info, imaevm_keyid);
+				if (siglen <= 1)
+					return siglen;
+				assert(siglen < (int)sizeof(sig));
+				siglen++;
+				sig[0] = EVM_IMA_XATTR_DIGSIG;
+				break;
+			default:
+				log_err("Internal error: Unsupported signature version: %d\n",
+					g_signature_version);
+				return -1;
+			}
 		}
-
-		if (siglen <= 1)
-			return siglen;
-		assert(siglen < (int)sizeof(sig));
 
 		fwrite(line, len, 1, stdout);
 		fprintf(stdout, " ");
-		bin2hex(sig, siglen + 1, stdout);
+		bin2hex(sig, siglen, stdout);
 		fprintf(stdout, "\n");
 	}
 

--- a/src/evmctl.c
+++ b/src/evmctl.c
@@ -3017,6 +3017,8 @@ static void usage(void)
 #ifdef DEBUG
 		"      --hmackey      path to symmetric key (default: /etc/keys/evm-key-plain)\n"
 #endif
+		"      --v2           create V2 signatures; this is the default\n"
+		"      --v3           create V3 signatures; this requires Linux 7.1 or later\n"
 		"  -v                 increase verbosity level\n"
 		"  -h, --help         display this help and exit\n"
 		"\n"
@@ -3092,6 +3094,8 @@ static struct option opts[] = {
 #if CONFIG_IMA_EVM_PROVIDER
 	{"provider", 1, 0, 149},
 #endif
+	{"v2", 0, 0, 150},
+	{"v3", 0, 0, 151},
 	{}
 
 };
@@ -3370,6 +3374,12 @@ int main(int argc, char *argv[])
 			access_info.type = IMAEVM_OSSL_ACCESS_TYPE_PROVIDER;
 			break;
 #endif
+		case 150: /* --v2 */
+			g_signature_version = SIGNATURE_V2;
+			break;
+		case 151: /* --v3 */
+			g_signature_version = SIGNATURE_V3;
+			break;
 		case '?':
 			exit(1);
 			break;

--- a/src/evmctl.c
+++ b/src/evmctl.c
@@ -828,7 +828,6 @@ static int cmd_sign_ima(struct command *cmd)
  */
 static int cmd_sign_hash(struct command *cmd)
 {
-	unsigned char sigv3_hash[MAX_DIGEST_SIZE];
 	unsigned char sig[MAX_SIGNATURE_SIZE];
 	unsigned char hash[MAX_DIGEST_SIZE];
 	size_t algolen = 0;
@@ -840,7 +839,6 @@ static int cmd_sign_hash(struct command *cmd)
 	const char *key;
 	char algo[7];	/* Current maximum fsverity hash algo name length */
 	ssize_t len;
-	int ret;
 
 	key = imaevm_params.keyfile ? : "/etc/keys/privkey_evm.pem";
 
@@ -888,19 +886,15 @@ static int cmd_sign_hash(struct command *cmd)
 			assert(hashlen / 2 <= sizeof(hash));
 			hex2bin(hash, hashp, hashlen / 2);
 
-			ret = calc_hash_sigv3(IMA_VERITY_DIGSIG, algo, hash,
-					      sigv3_hash);
-			if (ret < 0 || ret == 1) {
-				log_info("Failure to calculate fs-verity hash\n");
-				continue;
-			}
-
-			siglen = imaevm_signhash(algo, sigv3_hash, hashlen / 2,
-						 key, g_keypass, sig + 1, sigflags,
-						 &access_info, imaevm_keyid);
-
-			sig[0] = IMA_VERITY_DIGSIG;
-			sig[1] = DIGSIG_VERSION_3;	/* sigv3 */
+			psig = sig;
+			siglen = imaevm_create_sigv3(algo, hash,
+						     hashlen / 2, key, g_keypass,
+						     &psig, sizeof(sig), sigflags,
+						     IMA_VERITY_DIGSIG,
+						     &access_info, imaevm_keyid);
+			if (siglen <= 1)
+				return siglen;
+			assert(siglen <= (int)sizeof(sig));
 		} else {
 			/* Parse the shaXsum output */
 			token = strpbrk(line, " \t");

--- a/src/imaevm.h
+++ b/src/imaevm.h
@@ -282,4 +282,11 @@ int imaevm_hash_algo_from_sig(unsigned char *sig);
 const char *imaevm_hash_algo_by_id(int algo);
 int calc_hash_sigv3(enum evm_ima_xattr_type type, const char *algo, const unsigned char *in_hash, unsigned char *out_hash);
 
+int imaevm_create_sigv3(const char *hash_algo, const unsigned char *hash, int size,
+			const char *keyfile, const char *keypass,
+			unsigned char **sig, size_t siglen, long sigflags,
+			enum evm_ima_xattr_type xattr_type,
+			const struct imaevm_ossl_access *access_info,
+			uint32_t keyid);
+
 #endif

--- a/src/libimaevm.c
+++ b/src/libimaevm.c
@@ -623,7 +623,8 @@ int calc_hash_sigv3(enum evm_ima_xattr_type type, const char *algo,
 	unsigned int unused;
 
 	if (type != IMA_VERITY_DIGSIG &&
-	    type != EVM_IMA_XATTR_DIGSIG) {
+	    type != EVM_IMA_XATTR_DIGSIG &&
+	    type != EVM_XATTR_PORTABLE_DIGSIG) {
 		log_err("Only fsverity and IMA/EVM support signature format v3 (sigv3)\n");
 		return -EINVAL;
 	}

--- a/src/libimaevm.c
+++ b/src/libimaevm.c
@@ -378,17 +378,16 @@ static EVP_PKEY *find_keyid(struct public_key_entry *public_keys,
 		tail = entry;
 	}
 
-	/* add unknown keys to list */
-	entry = calloc(1, sizeof(struct public_key_entry));
-	if (!entry) {
-		perror("calloc");
-		return 0;
-	}
-	entry->keyid = keyid;
-	if (tail)
+	/* add unknown keys to tail of list */
+	if (tail) {
+		entry = calloc(1, sizeof(struct public_key_entry));
+		if (!entry) {
+			perror("calloc");
+			return 0;
+		}
+		entry->keyid = keyid;
 		tail->next = entry;
-	else
-		public_keys = entry;
+	}
 	log_err("key %d: %x (unknown keyid)\n", i, __be32_to_cpup(&keyid));
 	return 0;
 }

--- a/src/libimaevm.c
+++ b/src/libimaevm.c
@@ -400,7 +400,7 @@ void imaevm_free_public_keys(struct public_key_entry *public_keys)
 	while (entry) {
 		next = entry->next;
 		if (entry->key)
-			free(entry->key);
+			EVP_PKEY_free(entry->key);
 		free(entry);
 		entry = next;
 	}

--- a/src/libimaevm.c
+++ b/src/libimaevm.c
@@ -605,7 +605,7 @@ struct ima_file_id {
 int calc_hash_sigv3(enum evm_ima_xattr_type type, const char *algo,
 		    const unsigned char *in_hash, unsigned char *out_hash)
 {
-	struct ima_file_id file_id = { .hash_type = IMA_VERITY_DIGSIG };
+	struct ima_file_id file_id = { .hash_type = type };
 	uint8_t *data = (uint8_t *) &file_id;
 
 	const EVP_MD *md;
@@ -622,8 +622,9 @@ int calc_hash_sigv3(enum evm_ima_xattr_type type, const char *algo,
 	int hash_size;
 	unsigned int unused;
 
-	if (type != IMA_VERITY_DIGSIG) {
-		log_err("Only fsverity supports signature format v3 (sigv3)\n");
+	if (type != IMA_VERITY_DIGSIG &&
+	    type != EVM_IMA_XATTR_DIGSIG) {
+		log_err("Only fsverity and IMA/EVM support signature format v3 (sigv3)\n");
 		return -EINVAL;
 	}
 
@@ -1449,6 +1450,67 @@ int imaevm_signhash(const char *hashalgo, const unsigned char *hash, int size,
 			    access_info, keyid);
 }
 
+/*
+ * Create a v3 signature given a file hash
+ *
+ * @hash_algo: The hash algorithm to use for hashing
+ * @hash: The file hash
+ * @size: The size of the file hash
+ * @sig: A pointer to signature buffer pointer; if pointing to NULL, then
+ *       this function will allocate a buffer large enough for the signature
+ * @siglen: Size of the given signature buffer; if it is too small then
+ *          an error will be returned
+ * @sigflag: Flags related to the signature
+ * @xattr_type: Type of xattr that will be written; needed for creating
+ *              ima_file_id structure
+ * @access_info: Needed in case an engine or provider is used
+ * @keyid: The key id to use
+ *
+ * Note: This function behaves slightly different than older signature creation
+ *       functions because it already writes the xattr type to offset 0 in the
+ *       signature buffer.
+ */
+int imaevm_create_sigv3(const char *hash_algo, const unsigned char *hash, int size,
+			const char *keyfile, const char *keypass,
+			unsigned char **sig, size_t siglen, long sigflags,
+			enum evm_ima_xattr_type xattr_type,
+			const struct imaevm_ossl_access *access_info,
+			uint32_t keyid)
+{
+	unsigned char sigv3_hash[MAX_DIGEST_SIZE];
+	/* buffer capable of holding (more than) RSA-4096 signature; */
+	unsigned char sigbuf[1024];
+	int len, slen, err;
+
+	len = calc_hash_sigv3(xattr_type, hash_algo, hash, sigv3_hash);
+	if (len < 0 || len == 1) {
+		log_err("Failure to calculate v3 file hash\n");
+		return len;
+	}
+	assert(len <= sizeof(sigv3_hash));
+
+	err = imaevm_signhash(hash_algo, sigv3_hash, len, keyfile, keypass,
+			      &sigbuf[1], sigflags, access_info, keyid);
+	/* err holds error or signature length */
+	if (err < 0)
+		return err;
+	slen = 1 + err; /* will prepend xattr type */
+
+	if (!*sig) {
+		*sig = malloc(slen);
+		if (!*sig)
+			return -1;
+	} else if (siglen < slen) {
+		/* provided buffer is too small */
+		return -1;
+	}
+
+	sigbuf[0] = xattr_type;
+	sigbuf[1] = DIGSIG_VERSION_3;
+	memcpy(*sig, sigbuf, slen);
+
+	return slen;
+}
 
 int sign_hash(const char *hashalgo, const unsigned char *hash, int size,
 	      const char *keyfile, const char *keypass, unsigned char *sig)

--- a/tests/sign_verify.test
+++ b/tests/sign_verify.test
@@ -128,7 +128,7 @@ check_sign() {
   # OPTS (additional options for evmctl),
   # FILE (working file to sign).
   local "$@"
-  local key verifykey
+  local key verifykey sigver
   local FILE=${FILE:-$ALG.txt}
 
   # Normalize key filename if it's not a pkcs11 URI
@@ -213,18 +213,30 @@ check_sign() {
       verifykey=${key}
   fi
 
-  cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -verify ${verifykey} \
-	-signature $FILE.sig2 $FILE"
+  if [[ "$OPTS" =~ "--v3" ]]; then
+    # In case of v3 signatures we need to create ima_file_id now.
+    # All data for it can be found in PREFIX and by hashing $FILE.
+    echo -en "\x${PREFIX:2:2}\x${PREFIX:6:2}" > "$FILE.tmp"
+    # shellcheck disable=SC2086
+    openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -"$ALG" -binary "$FILE" >> "$FILE.tmp"
+    cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -verify ${verifykey} \
+	  -signature $FILE.sig2 $FILE.tmp"
+    sigver=3
+  else
+    cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -verify ${verifykey} \
+	  -signature $FILE.sig2 $FILE"
+    sigver=2
+  fi
   echo - "$cmd"
   if ! $cmd; then
     color_red_on_failure
-    echo "Signature v2 verification with openssl is failed."
+    echo "Signature v${sigver} verification with openssl is failed."
     color_restore
-    rm "$FILE.sig2"
+    rm "$FILE.sig2" "$FILE.tmp"
     return "$FAIL"
   fi
 
-  rm "$FILE.sig2"
+  rm "$FILE.sig2" "$FILE.tmp"
   return "$OK"
 }
 
@@ -390,6 +402,9 @@ sign_verify  rsa1024  sha384  0x030205:K:0080
 sign_verify  rsa1024  sha512  0x030206:K:0080
 sign_verify  rsa1024  rmd160  0x030203:K:0080
 
+sign_verify rsa1024  sha384  0x030305:K:0080 --v3
+sign_verify rsa1024  sha512  0x030306:K:0080 --v3
+
 # Test v2 signatures with ECDSA
 # Signature length is typically 0x34-0x38 bytes long, very rarely 0x33
 sign_verify  prime192v1 sha1   0x030202:K:003[345678]
@@ -404,6 +419,10 @@ sign_verify  prime256v1 sha224 0x030207:K:004[345678]
 sign_verify  prime256v1 sha256 0x030204:K:004[345678]
 sign_verify  prime256v1 sha384 0x030205:K:004[345678]
 sign_verify  prime256v1 sha512 0x030206:K:004[345678]
+
+sign_verify  prime256v1 sha256   0x030304:K:004[345678] --v3
+sign_verify  prime256v1 sha384   0x030305:K:004[345678] --v3
+sign_verify  prime256v1 sha512   0x030306:K:004[345678] --v3
 
 # If openssl 3.0 is installed, test the SM2/3 algorithm combination
 ssl_major_version=$(openssl version | sed -n 's/^OpenSSL \([^\.]\).*/\1/p')


### PR DESCRIPTION
This PR adds support for the V3 signatures for EVM & IMA for all supported key types. It implements a imaevm_create_sigv3() library function that takes the file hash as input and creates the hash of the ima_file_id needed for V3 signatures.

Add a few test cases for V3 signature creation and verification to sign_verify.test.

Later on, inside this function, we will check whether the signing key is an ML-DSA key and pass the ima_file_id structure to ML-DSA pure-mode signing saving the cycles for hashing this structure. Avoiding the hashing here will also save cycles when being able to avoid the hashing upon signature verification in Linux IMA.

Signature verification of V3 signatures is already supported in imaevm_verify_hash() through fsverify's V3 signature support.