### PR TITLE
fix: use snprintf instead of sprintf to prevent potential buffer overflow

### DIFF
--- a/src/pcr_tsspcrread.c
+++ b/src/pcr_tsspcrread.c
@@ -53,8 +53,8 @@ int tpm2_pcr_read(const char *algo_name, uint32_t pcr_handle, uint8_t *hwpcr,
 	char cmd[PATH_MAX + 50];
 	int ret;
 
-	sprintf(cmd, "%s -halg %s -ha %u -ns 2> /dev/null",
-		path, algo_name, pcr_handle);
+	snprintf(cmd, sizeof(cmd), "%s -halg %s -ha %u -ns 2> /dev/null",
+		 path, algo_name, pcr_handle);
 	fp = popen(cmd, "r");
 	if (!fp) {
 		ret = asprintf(errmsg, "popen failed: %s", strerror(errno));


### PR DESCRIPTION
Svace static analyzer reported BUFFER_OVERFLOW.SPRINTF at src/pcr_tsspcrread.c:56:

```
  An element of array '&cmd[0]' of size 4146 is accessed by an index
  with values in [0, +inf], which may lead to a buffer overflow.
```

While the buffer overflow is unlikely in practice because:

- The 'path' variable is obtained from find_in_path() which searches in PATH and is typically limited to PATH_MAX (4096) characters
- The 'algo_name' is a short algorithm name (e.g., "sha1", "sha256")
- The 'pcr_handle' is a small integer (PCR index)

Using snprintf is a defensive programming practice that eliminates the entire class of potential buffer overflow vulnerabilities (CWE-120).