### PR TITLE
Fix the PIN getter evmctl was using

### DIFF
--- a/src/libimaevm.c
+++ b/src/libimaevm.c
@@ -1177,7 +1177,9 @@ err_engine:
 #ifdef CONFIG_IMA_EVM_PROVIDER
 static int ui_get_pin(UI *ui, UI_STRING *uis)
 {
-	return UI_set_result(ui, uis, UI_get0_user_data(ui));
+	if (UI_set_result(ui, uis, UI_get0_user_data(ui)) != 0)
+		return 0;
+	return 1;
 }
 #endif
 

--- a/tests/sign_verify.test
+++ b/tests/sign_verify.test
@@ -172,9 +172,11 @@ check_sign() {
       echo >> "$FILE" # need at least 1 byte in the file for signing to work
       ;;
     *)
-      cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -sign $key -hex $FILE"
+      # pkcs11: If 'PIN' was passed, append it to the key URI to avoid a prompt for the PIN
+      cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -sign $key${PIN:+?pin-value=${PIN}} -hex $FILE"
       ;;
     esac
+    echo - "$cmd"
     if ! $cmd >/dev/null; then
       echo "${CYAN}$ALG ($key) test is skipped (openssl is unable to sign)$NORM"
       return "$SKIP"
@@ -474,8 +476,16 @@ expect_fail \
 _softhsm_setup "${WORKDIR}"
 if [ -n "${PKCS11_KEYURI}" ]; then
   if evmctl --help 2>/dev/null | grep -q engine; then
-    expect_pass check_sign FILE=pkcs11test TYPE=ima KEY="${PKCS11_KEYURI}" ALG=sha256 PREFIX=0x030204aabbccdd0100 OPTS="--keyid=aabbccdd" EVMCTL_ENGINE="--engine pkcs11"
-    expect_pass check_sign FILE=pkcs11test TYPE=ima KEY="${PKCS11_KEYURI}" ALG=sha1   PREFIX=0x030202aabbccdd0100 OPTS="--keyid=aabbccdd" EVMCTL_ENGINE="--engine pkcs11"
+    # strip PIN from URI and get PIN
+    pkcs11_keyuri_nopin=${PKCS11_KEYURI%\?*}
+    pin=${PKCS11_KEYURI#*pin-value=}
+
+    expect_pass check_sign FILE=pkcs11test TYPE=ima KEY="${pkcs11_keyuri_nopin}" \
+       ALG=sha256 PREFIX=0x030204aabbccdd0100 OPTS="--keyid=aabbccdd --pass=${pin}" \
+       EVMCTL_ENGINE="--engine pkcs11" PIN="${PIN}"
+    expect_pass check_sign FILE=pkcs11test TYPE=ima KEY="${PKCS11_KEYURI}" \
+       ALG=sha384 PREFIX=0x030205aabbccdd0100 OPTS="--keyid=aabbccdd" \
+       EVMCTL_ENGINE="--engine pkcs11"
   else
     __skip() { echo "pkcs11 test with engine is skipped since there is no engine support"; return "$SKIP"; }
     expect_pass __skip
@@ -486,9 +496,16 @@ if [ -n "${PKCS11_KEYURI}" ]; then
   if evmctl --help 2>/dev/null | grep -q provider && \
      openssl list -providers -provider pkcs11 2>/dev/null; then
     PKCS11_PRIVKEYURI=${PKCS11_KEYURI//type=public/type=private}
+    # strip PIN from URI and get PIN
+    pkcs11_keyuri_nopin=${PKCS11_PRIVKEYURI%\?*}
+    pin=${PKCS11_PRIVKEYURI#*pin-value=}
 
-    expect_pass check_sign FILE=pkcs11test TYPE=ima KEY="${PKCS11_PRIVKEYURI}" ALG=sha256 PREFIX=0x030204aabbccdd0100 OPTS="--keyid=aabbccdd" EVMCTL_ENGINE="--provider pkcs11"
-    expect_pass check_sign FILE=pkcs11test TYPE=ima KEY="${PKCS11_PRIVKEYURI}" ALG=sha1   PREFIX=0x030202aabbccdd0100 OPTS="--keyid=aabbccdd" EVMCTL_ENGINE="--provider pkcs11"
+    expect_pass check_sign FILE=pkcs11test TYPE=ima KEY="${pkcs11_keyuri_nopin}" \
+       ALG=sha256 PREFIX=0x030204aabbccdd0100 OPTS="--keyid=aabbccdd --pass=${pin}" \
+       EVMCTL_ENGINE="--provider pkcs11" PIN="${pin}"
+    expect_pass check_sign FILE=pkcs11test TYPE=ima KEY="${PKCS11_PRIVKEYURI}" \
+       ALG=sha384 PREFIX=0x030205aabbccdd0100 OPTS="--keyid=aabbccdd" \
+       EVMCTL_ENGINE="--provider pkcs11"
   else
     __skip() { echo "pkcs11 test with provider is skipped since no provider support or pkcs11 not installed"; return "$SKIP"; }
     expect_pass __skip


### PR DESCRIPTION
This PR fixes the PIN getter that evmctl was using for keys accessed using PKCS11. It was returning the wrong value from the callback function. It also adjusts test cases to test the PIN getter now by stripping the suffix `?pin-value=1234` from the URI and passing the PIN separately to evmctl using `--pass=...` to exercise the PIN getter. 

Since openssl command line tool is used to for test-signing with the PKCS11 URI, the pin-value needs to be appended to the URI to avoid openssl prompting for the PIN.
