### PR TITLE
Suppress errors from 'rm' trying to remove non-existing file

### DIFF
--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -229,7 +229,7 @@ _evmctl_run() {
       sed 's/^/  /' "$out"
     fi
     color_restore
-    rm "$out" "$ADD_DEL"
+    rm -f "$out" "$ADD_DEL"
     ADD_DEL=
     ADD_TEXT_FOR=
     return "$FAIL"


### PR DESCRIPTION
Suppress all of the following type of error messages by passing -f to 'rm' when running sign_verify.test.

rm: cannot remove '': No such file or directory