### PR TITLE
Fix two issues in previous patches

### DIFF
--- a/README
+++ b/README
@@ -85,7 +85,7 @@ OPTIONS
       --ignore-violations ignore ToMToU measurement violations
       --hmackey      path to symmetric key (default: /etc/keys/evm-key-plain)
       --v2           create V2 signatures; this is the default
-      --v3           create V3 signatures; this requires Linux 7.1 or later
+      --v3           create V3 signatures; this requires Linux 7.2 or later
   -v                 increase verbosity level
   -h, --help         display this help and exit
 

--- a/src/evmctl.c
+++ b/src/evmctl.c
@@ -3012,7 +3012,7 @@ static void usage(void)
 		"      --hmackey      path to symmetric key (default: /etc/keys/evm-key-plain)\n"
 #endif
 		"      --v2           create V2 signatures; this is the default\n"
-		"      --v3           create V3 signatures; this requires Linux 7.1 or later\n"
+		"      --v3           create V3 signatures; this requires Linux 7.2 or later\n"
 		"  -v                 increase verbosity level\n"
 		"  -h, --help         display this help and exit\n"
 		"\n"
@@ -3176,6 +3176,7 @@ static ENGINE *setup_engine(const char *engine_id)
 
 int main(int argc, char *argv[])
 {
+	bool version_chosen = false;
 	int err = 0, c, lind;
 	unsigned long keyid;
 	char *eptr;
@@ -3369,9 +3370,19 @@ int main(int argc, char *argv[])
 			break;
 #endif
 		case 150: /* --v2 */
+			if (version_chosen &&
+			    g_signature_version != SIGNATURE_V2) {
+				log_info("Switching to use v2 signatures.\n");
+			}
+			version_chosen = true;
 			g_signature_version = SIGNATURE_V2;
 			break;
 		case 151: /* --v3 */
+			if (version_chosen &&
+			    g_signature_version != SIGNATURE_V3) {
+				log_info("Switching to use v3 signatures.\n");
+			}
+			version_chosen = true;
 			g_signature_version = SIGNATURE_V3;
 			break;
 		case '?':

--- a/tests/sign_verify.test
+++ b/tests/sign_verify.test
@@ -216,11 +216,12 @@ check_sign() {
   if [[ "$OPTS" =~ "--v3" ]]; then
     # In case of v3 signatures we need to create ima_file_id now.
     # All data for it can be found in PREFIX and by hashing $FILE.
-    echo -en "\x${PREFIX:2:2}\x${PREFIX:6:2}" > "$FILE.tmp"
+    echo -en "\x${PREFIX:2:2}\x${PREFIX:6:2}" > "$FILE.ima_file_id"
     # shellcheck disable=SC2086
-    openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -"$ALG" -binary "$FILE" >> "$FILE.tmp"
+    openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -"$ALG" -binary "$FILE" >> \
+          "$FILE.ima_file_id"
     cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -verify ${verifykey} \
-	  -signature $FILE.sig2 $FILE.tmp"
+	  -signature $FILE.sig2 $FILE.ima_file_id"
     sigver=3
   else
     cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -verify ${verifykey} \
@@ -230,13 +231,13 @@ check_sign() {
   echo - "$cmd"
   if ! $cmd; then
     color_red_on_failure
-    echo "Signature v${sigver} verification with openssl is failed."
+    echo "Signature v${sigver} verification with openssl failed."
     color_restore
-    rm "$FILE.sig2" "$FILE.tmp"
+    rm -f "$FILE.sig2" "$FILE.ima_file_id"
     return "$FAIL"
   fi
 
-  rm "$FILE.sig2" "$FILE.tmp"
+  rm -f "$FILE.sig2" "$FILE.ima_file_id"
   return "$OK"
 }
 


### PR DESCRIPTION
- Notify the user about the signature version that will be created if --v3 is first passed and then --v2 (or vice versa)
- Rename the suffix of a temporary file and fix an error message