### PR TITLE
Add support for ML-DSA PQC keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         if [ "$count" -eq 0 ]; then
           exit 0
         fi
-        scripts/checkpatch.pl patches/*  --strict --terse  --no-tree --ignore CONST_STRUCT,VOLATILE,SPLIT_STRING,FILE_PATH_CHANGES,EXECUTE_PERMISSIONS,UNKNOWN_COMMIT_ID,BAD_SIGN_OFF,PREFER_DEFINED_ATTRIBUTE_MACRO,PREFER_KERNEL_TYPES
+        scripts/checkpatch.pl patches/*  --strict --terse  --no-tree --ignore CONST_STRUCT,VOLATILE,SPLIT_STRING,FILE_PATH_CHANGES,EXECUTE_PERMISSIONS,UNKNOWN_COMMIT_ID,BAD_SIGN_OFF,PREFER_DEFINED_ATTRIBUTE_MACRO,PREFER_KERNEL_TYPES,EMBEDDED_FUNCTION_NAME
 
   build:
     needs: review

--- a/README
+++ b/README
@@ -153,7 +153,8 @@ in the kernel (since kernel 3.9). CONFIG_INTEGRITY_ASYMMETRIC_KEYS must be enabl
 
 For v2 and v3 signatures x509 certificate (containing the public key) could be appended to the
 private key (they both are in PEM format) to automatically extract keyid from its Subject
-Key Identifier (SKID).
+Key Identifier (SKID). v3 signatures can be created with the --v3 option. This signature format
+is required for signing with ML-DSA keys.
 
 Integrity keyrings
 ----------------

--- a/examples/functions
+++ b/examples/functions
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # For help screens to display supported algorithms
-SUPPORTED_ALGORITHMS="rsa:2048, rsa:3072, rsa:4096, prime256v1, secp384r1, and secp521r1"
+SUPPORTED_ALGORITHMS="rsa:2048, rsa:3072, rsa:4096, prime256v1, secp384r1, secp521r1, mldsa44, mldsa65, and mldsa87"
 
 # Get the OpenSSL keyalgo parameter
 # @param1: The key algorithm; must be a name that OpenSSL command line tool
@@ -16,6 +16,15 @@ get_ossl_keyalgo()
 	prime256v1|secp384r1|secp521r1)
 		echo "ec"
 		;;
+	mldsa44|mldsa65|mldsa87)
+		# ML-DSA requires OpenSSL 3.5.0 or later
+		maj=$(openssl version | awk '{print $2}' | cut -d. -f1)
+		min=$(openssl version | awk '{print $2}' | cut -d. -f2)
+		if [ "${maj}" -lt 3 ] || { [ "${maj}" -eq 3 ] && [ "${min}" -lt 5 ]; }; then
+			echo "The openssl tool is too old (v${maj}.${min}) to support ML-DSA. Need at least v3.5.0." >&2
+			return 1
+		fi
+		echo "$1"
 	esac
 }
 
@@ -30,6 +39,9 @@ get_ossl_keyalgo_detail()
 		;;
 	prime256v1|secp384r1|secp521r1)
 		echo "-pkeyopt ec_paramgen_curve:${keyalgo}"
+		;;
+	mldsa44|mldsa65|mldsa87)
+		echo ""
 		;;
 	esac
 }
@@ -172,6 +184,9 @@ __EOF__
 		;;
 	primve256v1|secp384r1|secp521r1)
 		openssl ec -pubout -in privkey_evm.pem -out pubkey_evm.pem
+		;;
+	mldsa44|mldsa65|mldsa87)
+		openssl pkey -pubout -in privkey_evm.pem -out pubkey_evm.pem
 		;;
 	esac
 

--- a/src/evmctl.c
+++ b/src/evmctl.c
@@ -347,7 +347,7 @@ static int calc_evm_hash(const char *file, const char *hash_algo,
 	EVP_MD_CTX *pctx;
 	unsigned int mdlen;
 	char **xattrname;
-	char xattr_value[1024];
+	char xattr_value[MAX_SIGNATURE_SIZE];
 	char list[1024];
 	ssize_t list_size;
 	char uuid[16];

--- a/src/evmctl.c
+++ b/src/evmctl.c
@@ -617,6 +617,10 @@ static int sign_evm(const char *file, char *hash_algo, const char *key)
 		if (err < 0) {
 			log_errno_reset(LOG_ERR, "Setting EVM xattr failed: %s",
 					file);
+			if (len >= 4096)
+				log_err("The signature with %zu bytes is likely too large for the file "
+					"extended attribute. Consider using a different key type.\n",
+					len);
 			return err;
 		}
 	}

--- a/src/imaevm.h
+++ b/src/imaevm.h
@@ -74,8 +74,11 @@ typedef struct ossl_provider_st OSSL_PROVIDER;
 #define	DATA_SIZE	4096
 #define SHA1_HASH_LEN   20
 
+#define ML_DSA_87_SIGNATURE_SIZE	4627
+
 #define MAX_DIGEST_SIZE		64
-#define MAX_SIGNATURE_SIZE	1024
+#define MAX_SIGNATURE_SIZE	(1 + sizeof(struct signature_v2_hdr) + \
+				 ML_DSA_87_SIGNATURE_SIZE)
 
 /*
  * The maximum template data size is dependent on the template format. For

--- a/src/libimaevm.c
+++ b/src/libimaevm.c
@@ -1343,7 +1343,8 @@ static int sign_hash_v2(const char *algo, const unsigned char *hash,
 	hdr->hash_algo = imaevm_get_hash_algo(algo);
 	if (hdr->hash_algo == (uint8_t)-1) {
 		log_err("sign_hash_v2: hash algo is unknown: %s\n", algo);
-		return -1;
+		len = -1;
+		goto err_nomsg;
 	}
 
 #if defined(EVP_PKEY_SM2) && OPENSSL_VERSION_NUMBER < 0x30000000
@@ -1395,6 +1396,7 @@ err:
 			ERR_reason_error_string(ERR_peek_error()), st);
 		output_openssl_errors();
 	}
+err_nomsg:
 	EVP_PKEY_CTX_free(ctx);
 	EVP_PKEY_free(pkey);
 	return len;

--- a/src/libimaevm.c
+++ b/src/libimaevm.c
@@ -37,6 +37,9 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+#include <openssl/core_names.h>
+#endif
 
 #if CONFIG_IMA_EVM_ENGINE
 #include <openssl/engine.h>
@@ -81,7 +84,24 @@ struct libimaevm_params imaevm_params = {
 	.hash_algo = DEFAULT_HASH_ALGO,
 };
 
+#define HASH_MAX_DIGESTSIZE 64	/* kernel HASH_MAX_DIGESTSIZE is 64 bytes */
+
+struct ima_file_id {
+	__u8 hash_type;		/* xattr type [enum evm_ima_xattr_type] */
+	__u8 hash_algorithm;	/* Digest algorithm [enum hash_algo] */
+	__u8 hash[HASH_MAX_DIGESTSIZE];
+} __packed;
+
 static void __attribute__ ((constructor)) libinit(void);
+
+/* RSA, ECDSA, ECRDSA, and SM2 all use hashes for signing */
+static inline bool keytype_uses_hash_for_signing(const char *keytype)
+{
+	return strcmp("RSA", keytype) == 0 ||
+		strcmp("EC", keytype) == 0 ||
+		strncmp("GOST2012_", keytype, 9) == 0 ||
+		strcmp("SM2", keytype) == 0;
+}
 
 void imaevm_do_hexdump(FILE *fp, const void *ptr, int len, bool newline)
 {
@@ -460,6 +480,81 @@ void init_public_keys(const char *keyfiles)
 	imaevm_init_public_keys(keyfiles, &g_public_keys);
 }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30500000
+static int verify_mldsa(EVP_PKEY *pkey,
+			const char *algo,
+			const unsigned char *hash, int hash_size,
+			unsigned char *sig, int siglen,
+			enum evm_ima_xattr_type type,
+			const char *file)
+{
+	struct signature_v2_hdr *hdr = (struct signature_v2_hdr *)sig;
+	struct ima_file_id file_id = { .hash_type = type, };
+	const char *keytype = EVP_PKEY_get0_type_name(pkey);
+	uint8_t *data = (uint8_t *)&file_id;
+	EVP_SIGNATURE *sig_alg = NULL;
+	unsigned int unused;
+	EVP_PKEY_CTX *ctx;
+	int hash_algo;
+	const char *st;
+	int ret = -1;
+
+	if (!algo) {
+		log_err("Hash algorithm unspecified\n");
+		return -EINVAL;
+	}
+	if (hash_size > HASH_MAX_DIGESTSIZE) {
+		log_err("hash_size is too large\n");
+		return -EINVAL;
+	}
+
+	hash_algo = imaevm_get_hash_algo(algo);
+	if (hash_algo < 0) {
+		log_err("Hash algorithm %s not supported\n", algo);
+		return -EINVAL;
+	}
+	file_id.hash_algorithm = hash_algo;
+
+	memcpy(file_id.hash, hash, hash_size);
+	unused = HASH_MAX_DIGESTSIZE - hash_size;
+
+	st = "EVP_PKEY_CTX_new";
+	ctx = EVP_PKEY_CTX_new(pkey, NULL);
+	if (!ctx)
+		goto err;
+	st = "EVP_SIGNATURE_fetch";
+	sig_alg = EVP_SIGNATURE_fetch(NULL, keytype, NULL);
+	if (!sig_alg)
+		goto err;
+	st = "EVP_PKEY_verify_message_init";
+	if (!EVP_PKEY_verify_message_init(ctx, sig_alg, NULL))
+		goto err;
+	st = "EVP_PKEY_verify";
+	ret = EVP_PKEY_verify(ctx, sig + sizeof(*hdr),
+			      siglen - sizeof(*hdr),
+			      data, sizeof(file_id) - unused);
+	if (ret == 1) {
+		ret = 0;
+	} else if (ret == 0) {
+		log_err("%s: verification failed: %d (%s)\n",
+			file, ret, ERR_reason_error_string(ERR_get_error()));
+		output_openssl_errors();
+		ret = 1;
+	}
+err:
+	if (ret < 0 || ret > 1) {
+		log_err("%s: verification failed: %d (%s) in %s\n",
+			file, ret, ERR_reason_error_string(ERR_peek_error()),
+			st);
+		output_openssl_errors();
+		ret = -1;
+	}
+	EVP_SIGNATURE_free(sig_alg);
+	EVP_PKEY_CTX_free(ctx);
+	return ret;
+}
+#endif
+
 /*
  * Verify a signature, prefixed with the signature_v2_hdr, either based
  * directly or indirectly on the file data hash.
@@ -577,6 +672,28 @@ static int verify_hash_v3(struct public_key_entry *public_keys,
 {
 	unsigned char sigv3_hash[MAX_DIGEST_SIZE];
 	int ret;
+#if OPENSSL_VERSION_NUMBER >= 0x30500000
+	struct signature_v2_hdr *hdr = (struct signature_v2_hdr *)(sig + 1);
+	const char *keytype;
+	EVP_PKEY *pkey; // do not free here
+
+	pkey = find_keyid(public_keys, hdr->keyid);
+	if (!pkey) {
+		uint32_t keyid = hdr->keyid;
+
+		if (imaevm_params.verbose > LOG_INFO)
+			log_info("%s: verification failed: unknown keyid %x\n",
+				 file, __be32_to_cpup(&keyid));
+		return -1;
+	}
+
+	keytype = EVP_PKEY_get0_type_name(pkey);
+
+	if (keytype && !keytype_uses_hash_for_signing(keytype))
+		return verify_mldsa(pkey, hash_algo,
+				    hash, size, sig + 1, siglen - 1,
+				    sig[0], file);
+#endif
 
 	ret = calc_hash_sigv3(sig[0], hash_algo, hash, sigv3_hash);
 	if (ret < 0)
@@ -586,14 +703,6 @@ static int verify_hash_v3(struct public_key_entry *public_keys,
 	return verify_hash_common(public_keys, file, hash_algo, sigv3_hash,
 				  size, sig + 1, siglen - 1);
 }
-
-#define HASH_MAX_DIGESTSIZE 64	/* kernel HASH_MAX_DIGESTSIZE is 64 bytes */
-
-struct ima_file_id {
-	__u8 hash_type;		/* xattr type [enum evm_ima_xattr_type] */
-	__u8 hash_algorithm;	/* Digest algorithm [enum hash_algo] */
-	__u8 hash[HASH_MAX_DIGESTSIZE];
-} __packed;
 
 /*
  * Calculate the signature format version 3 hash based on the portion
@@ -1292,7 +1401,7 @@ out:
 #endif /* CONFIG_SIGV1 */
 
 /*
- * @sig is assumed to be of (MAX_SIGNATURE_SIZE - 1) size
+ * @sig is assumed to be of at least (1024 - 1) size
  * Return: -1 signing error, >0 length of signature
  */
 static int sign_hash_v2(const char *algo, const unsigned char *hash,
@@ -1306,6 +1415,7 @@ static int sign_hash_v2(const char *algo, const unsigned char *hash,
 	EVP_PKEY *pkey;
 	char name[20];
 	EVP_PKEY_CTX *ctx = NULL;
+	const char *keytype;
 	const EVP_MD *md;
 	size_t sigsize;
 	const char *st;
@@ -1336,6 +1446,16 @@ static int sign_hash_v2(const char *algo, const unsigned char *hash,
 	pkey = read_priv_pkey(keyfile, keypass, access_info, keyid);
 	if (!pkey)
 		return -1;
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+	keytype = EVP_PKEY_get0_type_name(pkey);
+	/* if it's neither an RSA, EC(R)DSA, nor SM2 key then it cannot be used here */
+	if (keytype && !keytype_uses_hash_for_signing(keytype)) {
+		log_err("sign_hash_v2: Cannot use '%s' type of key\n", keytype);
+		len = -1;
+		goto err_nomsg;
+	}
+#endif
 
 	hdr = (struct signature_v2_hdr *)sig;
 	hdr->version = (uint8_t) DIGSIG_VERSION_2;
@@ -1380,7 +1500,7 @@ static int sign_hash_v2(const char *algo, const unsigned char *hash,
 	if (!EVP_PKEY_CTX_set_signature_md(ctx, md))
 		goto err;
 	st = "EVP_PKEY_sign";
-	sigsize = MAX_SIGNATURE_SIZE - sizeof(struct signature_v2_hdr) - 1;
+	sigsize = 1024 - sizeof(struct signature_v2_hdr) - 1;
 	if (!EVP_PKEY_sign(ctx, hdr->sig, &sigsize, hash, size))
 		goto err;
 	len = (int)sigsize;
@@ -1453,6 +1573,113 @@ int imaevm_signhash(const char *hashalgo, const unsigned char *hash, int size,
 			    access_info, keyid);
 }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30500000
+static int create_sigv3_mldsa(EVP_PKEY *pkey, const char *algo,
+			      const unsigned char *hash, int hash_size,
+			      unsigned char **sig, size_t siglen,
+			      enum evm_ima_xattr_type type,
+			      const struct imaevm_ossl_access *access_info,
+			      uint32_t keyid)
+{
+	const char *keytype = EVP_PKEY_get0_type_name(pkey);
+	struct ima_file_id file_id = { .hash_type = type, };
+	uint8_t *data = (uint8_t *)&file_id;
+	EVP_SIGNATURE *sig_alg = NULL;
+	struct signature_v2_hdr *hdr;
+	EVP_PKEY_CTX *ctx = NULL;
+	bool allocated = false;
+	unsigned int unused;
+	ssize_t slen = -1;
+	size_t needlen;
+	const char *st;
+	int hash_algo;
+	char name[20];
+	int ret = -1;
+
+	hash_algo = imaevm_get_hash_algo(algo);
+	if (hash_algo < 0) {
+		log_err("Hash algorithm %s not supported\n", algo);
+		return -EINVAL;
+	}
+	if (hash_size > HASH_MAX_DIGESTSIZE) {
+		log_err("hash_size is too large\n");
+		return -EINVAL;
+	}
+	file_id.hash_algorithm = hash_algo;
+	memcpy(file_id.hash, hash, hash_size);
+	unused = HASH_MAX_DIGESTSIZE - hash_size;
+
+	st = "EVP_PKEY_CTX_new";
+	ctx = EVP_PKEY_CTX_new(pkey, NULL);
+	if (!ctx)
+		goto err;
+	st = "EVP_SIGNATURE_fetch";
+	sig_alg = EVP_SIGNATURE_fetch(NULL, keytype, NULL);
+	if (!sig_alg)
+		goto err;
+	st = "EVP_PKEY_sign_init";
+	if (!EVP_PKEY_sign_message_init(ctx, sig_alg, NULL))
+		goto err;
+	st = "EVP_PKEY_sign";
+	/* query for size of signature */
+	if (!EVP_PKEY_sign(ctx, NULL, (size_t *)&slen,
+			   data, sizeof(file_id) - unused)) {
+		slen = -1;
+		goto err;
+	}
+
+	needlen = 1 + sizeof(*hdr) + slen;
+	if (*sig) {
+		if (siglen < needlen) {
+			log_err("Buffer of size %zu is too small for signature "
+				"of size %zu\n", siglen, needlen);
+			goto err;
+		}
+	} else {
+		*sig = malloc(needlen);
+		if (!*sig) {
+			perror("malloc");
+			goto err;
+		}
+		allocated = true;
+	}
+	hdr = (struct signature_v2_hdr *)(*sig + 1);
+
+	if (!EVP_PKEY_sign(ctx, hdr->sig, (size_t *)&slen,
+			   data, sizeof(file_id) - unused)) {
+		slen = -1;
+		goto err;
+	}
+
+	(*sig)[0] = type;
+	hdr->version = DIGSIG_VERSION_3;
+	hdr->hash_algo = hash_algo;
+	if (keyid)
+		keyid = htonl(keyid);
+	else
+		calc_keyid_v2(&keyid, name, pkey);
+	hdr->keyid = keyid;
+	hdr->sig_size = __cpu_to_be16(slen);
+
+	ret = needlen;
+	log_info("evm/ima signature: %d bytes\n", ret);
+
+err:
+	EVP_SIGNATURE_free(sig_alg);
+	EVP_PKEY_CTX_free(ctx);
+	if (slen == -1) {
+		log_err("create_sigv3_mldsa signing failed: (%s) in %s\n",
+			ERR_reason_error_string(ERR_peek_error()), st);
+		output_openssl_errors();
+	}
+	if (ret < 0 && allocated) {
+		free(*sig);
+		*sig = NULL;
+	}
+	return ret;
+}
+#endif
+
 /*
  * Create a v3 signature given a file hash
  *
@@ -1484,6 +1711,29 @@ int imaevm_create_sigv3(const char *hash_algo, const unsigned char *hash, int si
 	/* buffer capable of holding (more than) RSA-4096 signature; */
 	unsigned char sigbuf[1024];
 	int len, slen, err;
+#if OPENSSL_VERSION_NUMBER >= 0x30500000
+	const char *keytype;
+	EVP_PKEY *pkey;
+
+	if (access_info) {
+		err = check_ossl_access(access_info);
+		if (err)
+			return err;
+	}
+	pkey = read_priv_pkey(keyfile, keypass, access_info, keyid);
+	if (!pkey)
+		return -1;
+
+	keytype = EVP_PKEY_get0_type_name(pkey);
+	if (keytype && strncmp("ML-DSA-", keytype, 7) == 0) {
+		slen = create_sigv3_mldsa(pkey, hash_algo, hash, size,
+					  sig, siglen,
+					  xattr_type, access_info, keyid);
+		EVP_PKEY_free(pkey);
+		return slen;
+	}
+	EVP_PKEY_free(pkey);
+#endif
 
 	len = calc_hash_sigv3(xattr_type, hash_algo, hash, sigv3_hash);
 	if (len < 0 || len == 1) {

--- a/tests/gen-keys.sh
+++ b/tests/gen-keys.sh
@@ -148,6 +148,28 @@ if [ -x /opt/openssl3/bin/openssl ]; then
   done)
 fi
 
+# If creating mldsa44 key works, create all ML-DSA sizes
+if openssl genpkey -algorithm mldsa44 &>/dev/null; then
+  for mldsa in mldsa44 mldsa65; do
+    if [ "$1" = clean ] || [ "$1" = force ]; then
+      rm -f test-$mldsa.cer test-$mldsa.key test-$mldsa.pub
+    fi
+    if [ "$1" = clean ]; then
+      continue
+    fi
+    if [ ! -e test-$mldsa.key ]; then
+      log openssl req -verbose -new -nodes -utf8 -days 10000 -batch -x509 \
+        -config test-ca.conf \
+        -newkey "$mldsa" \
+        -out test-$mldsa.cer -outform DER \
+        -keyout test-$mldsa.key
+      if [ -s test-$mldsa.key ]; then
+        log openssl pkey -in test-$mldsa.key -out test-$mldsa.pub -pubout
+      fi
+    fi
+  done
+fi
+
 # This script leaves test-ca.conf, *.cer, *.pub, *.key files for sing/verify tests.
 # They are never deleted except by `make distclean'.
 

--- a/tests/sign_verify.test
+++ b/tests/sign_verify.test
@@ -166,8 +166,15 @@ check_sign() {
     fi
 
     # Can openssl sign with this digest and key?
-    cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -sign $key -hex $FILE"
-    echo - "$cmd"
+    case "${KEY:0:10}" in
+    "test-mldsa")
+      cmd="openssl pkeyutl -sign -inkey $key -in $FILE"
+      echo >> "$FILE" # need at least 1 byte in the file for signing to work
+      ;;
+    *)
+      cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -sign $key -hex $FILE"
+      ;;
+    esac
     if ! $cmd >/dev/null; then
       echo "${CYAN}$ALG ($key) test is skipped (openssl is unable to sign)$NORM"
       return "$SKIP"
@@ -220,8 +227,17 @@ check_sign() {
     # shellcheck disable=SC2086
     openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -"$ALG" -binary "$FILE" >> \
           "$FILE.ima_file_id"
-    cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -verify ${verifykey} \
-	  -signature $FILE.sig2 $FILE.ima_file_id"
+
+    case "${KEY:0:10}" in
+    "test-mldsa")
+      # ML-DSA does not accept a hash algorithm on command line
+      cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM       -verify ${verifykey} \
+	    -signature $FILE.sig2 $FILE.ima_file_id"
+      ;;
+    *)
+      cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -verify ${verifykey} \
+	    -signature $FILE.sig2 $FILE.ima_file_id"
+    esac
     sigver=3
   else
     cmd="openssl dgst $OPENSSL_ENGINE $OPENSSL_KEYFORM -$ALG -verify ${verifykey} \
@@ -424,6 +440,13 @@ sign_verify  prime256v1 sha512 0x030206:K:004[345678]
 sign_verify  prime256v1 sha256   0x030304:K:004[345678] --v3
 sign_verify  prime256v1 sha384   0x030305:K:004[345678] --v3
 sign_verify  prime256v1 sha512   0x030306:K:004[345678] --v3
+
+sign_verify  mldsa44    sha256   0x030304:K:0974 --v3
+sign_verify  mldsa44    sha384   0x030305:K:0974 --v3
+sign_verify  mldsa44    sha512   0x030306:K:0974 --v3
+sign_verify  mldsa65    sha256   0x030304:K:0ced --v3
+sign_verify  mldsa65    sha384   0x030305:K:0ced --v3
+sign_verify  mldsa65    sha512   0x030306:K:0ced --v3
 
 # If openssl 3.0 is installed, test the SM2/3 algorithm combination
 ssl_major_version=$(openssl version | sed -n 's/^OpenSSL \([^\.]\).*/\1/p')


### PR DESCRIPTION
This series adds support for ML-DSA PQC key support to the library and evmctl and adds test cases for signing and verifying to the sign_verfiy.test. It requires availability of OpenSSL 3.5.

This is a continuation of PR #19.