### PR TITLE
CI: Have Alpine also install softhsm and the pkcs11 provider

### DIFF
--- a/ci/alpine.sh
+++ b/ci/alpine.sh
@@ -47,7 +47,10 @@ apk add \
 	wget \
 	which \
 	xxd \
-	gawk
+	gawk \
+	libp11 \
+	gnutls-utils \
+	softhsm
 
 if [ ! "$TSS" ]; then
 	apk add git


### PR DESCRIPTION
The pkcs11 provider is called libp11 on Alpine and provides
 - /usr/lib/engines-3/libpkcs11.so
 - /usr/lib/engines-3/pkcs11.so
 - /usr/lib/ossl-modules/libpkcs11.so
 - /usr/lib/ossl-modules/pkcs11prov.so